### PR TITLE
Add community guideline doc from iqc21 repo (with edits)

### DIFF
--- a/guidelines-for-participants.md
+++ b/guidelines-for-participants.md
@@ -1,0 +1,24 @@
+# Guidelines for Participation
+
+The IBM Quantum Challenge Africa 2021 and the Qiskit Community team are committed to maintaining the highest level of enjoyment, accessibility, and inclusivity by maintaining an environment of respect, empathy, and compassion for others. In order to support that, we ask that each participant review the Qiskit Community Code of Conduct before the event, and be familiar with our community standards to join us in maintaining a safe and welcoming event for all.
+
+We have zero tolerance for any type of harassment, and welcome each and every attendee as you support these values and make this hackathon and the Qiskit Community a friendly and open space for everyone.
+
+[Click here to Review Qiskit Community Code of Conduct](https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md#our-pledge)
+
+*As this event is a challenge, sharing solutions/answers is strictly forbidden and can lead to potential disqualification from the event. We encourage you to ask questions in the dedicated Slack channel [#challenge-africa-2021](https://qiskit.slack.com/archives/C02C8MKP153) if you need additional guidance.*
+
+## IBM Quantum Challenge Africa 2021 Event Values
+
+- **Be Engaged:** Connect with each other & have FUN!
+- **Be Inclusive:** Use shared language, be empathetic, & be aware of cultures and backgrounds
+- **Be Respectful:** Respect each other, & use respectful language
+- **Be Positive:** Assume the best intentions, & have forward-looking outlook
+- **Be Honest:** To ensure a positive learning experience for everyone, do not share the answers to the exercises with any participant or publicly within the Slack channel. We are all here to learn & have fun together!
+- **Be You!!!** Share about yourself and your goals, be real, be genuine, & let yourself be comfortable
+
+Throughout the event, in the case that you may encounter any offensive behavior or violations of the Qiskit Community Code of Conduct, we encourage you to report the violation by submitting [this form](https://airtable.com/shrl5mEF4Eun1aIDm). All reports are treated with the strictest level of confidentiality, and we have an absolute zero-tolerance policy on any form of retaliation.
+
+The events team, admins, and moderators are all here to support the event and community - so please feel comfortable reaching out directly with any questions, concerns, or reports as well.
+
+This community continues to be open, friendly, and welcoming, and with your support, we will be able to maintain that throughout this event, and also in the years to come.  Thank you!


### PR DESCRIPTION
Changes include
- Rename challenge to `IBM Quantum Challenge Africa 2021`
- Fix incorrect capitalization of Slack
- Change Slack channel name to #challenge-africa-2021
- Change Slack channel link to match the channel name